### PR TITLE
threading for CBCentralManager delegate

### DIFF
--- a/sdk/WHS2-SDK/MBLeManager.m
+++ b/sdk/WHS2-SDK/MBLeManager.m
@@ -15,8 +15,12 @@
 -(id)init {
     self = [super init];
     if(self) {
-        dispatch_queue_t centralQueue = dispatch_queue_create("jp.co.uniontool.myBeat", DISPATCH_QUEUE_SERIAL);
-        self.centralManager = [[CBCentralManager alloc]initWithDelegate:self queue:centralQueue options:nil];
+        if ([[[UIDevice currentDevice] systemVersion] floatValue] >= 7.0) {
+            dispatch_queue_t centralQueue = dispatch_queue_create("jp.co.uniontool.myBeat", DISPATCH_QUEUE_SERIAL);
+            self.centralManager = [[CBCentralManager alloc]initWithDelegate:self queue:centralQueue options:nil];
+        } else {
+            self.centralManager = [[CBCentralManager alloc]initWithDelegate:self queue:nil];
+        }
         self.whsServiceUUID = [CBUUID UUIDWithString:ServiceWhsUuid];
         self.whsCharacteristicsUUID = [CBUUID UUIDWithString:CharacteristicsWhsUuid];
         self.foundPeripherals = [[NSMutableArray alloc] init];

--- a/sdk/WHS2-SDK/MBLeManager.m
+++ b/sdk/WHS2-SDK/MBLeManager.m
@@ -15,7 +15,8 @@
 -(id)init {
     self = [super init];
     if(self) {
-        self.centralManager = [[CBCentralManager alloc]initWithDelegate:self queue:nil];
+        dispatch_queue_t centralQueue = dispatch_queue_create("jp.co.uniontool.myBeat", DISPATCH_QUEUE_SERIAL);
+        self.centralManager = [[CBCentralManager alloc]initWithDelegate:self queue:centralQueue options:nil];
         self.whsServiceUUID = [CBUUID UUIDWithString:ServiceWhsUuid];
         self.whsCharacteristicsUUID = [CBUUID UUIDWithString:CharacteristicsWhsUuid];
         self.foundPeripherals = [[NSMutableArray alloc] init];

--- a/sdk/WHS2-SDK/MBLeManager.m
+++ b/sdk/WHS2-SDK/MBLeManager.m
@@ -1,6 +1,7 @@
 #import "MBLeManager.h"
 #import "MBWhsService.h"
 #import "MeasureReceiveProtocol.h"
+#import <UIKit/UIKit.h>
 
 @interface MBLeManager() <CBCentralManagerDelegate, CBPeripheralDelegate>
 @property (nonatomic) NSTimer *scanStopTimer;


### PR DESCRIPTION
Fixes iOS 7 warning:

```
CoreBluetooth[WARNING] <CBCentralManager: 0x15654540> is disabling duplicate filtering, but is using the default queue (main thread) for delegate events
```

http://stackoverflow.com/questions/18970247/cbcentralmanager-changes-for-ios-7